### PR TITLE
add L1 poll delay

### DIFF
--- a/cli/cmd/rollup_info.go
+++ b/cli/cmd/rollup_info.go
@@ -33,7 +33,8 @@ var RollupInfoCmd = &cobra.Command{
 		utils.NoErr(err)
 
 		r := rollup.NewRollup(n, &rollup.Opts{
-			PollDelay:             time.Duration(cfg.Rollup.PollDelay) * time.Millisecond,
+			L1PollDelay:           time.Duration(cfg.Rollup.L1PollDelay) * time.Millisecond,
+			L2PollDelay:           time.Duration(cfg.Rollup.L2PollDelay) * time.Millisecond,
 			BundleSize:            cfg.Rollup.BundleSize,
 			StoreCelestiaPointers: cfg.Rollup.StoreCelestiaPointers,
 			StoreHeaders:          cfg.Rollup.StoreHeaders,

--- a/cli/cmd/rollup_next.go
+++ b/cli/cmd/rollup_next.go
@@ -33,7 +33,8 @@ var RollupNextCmd = &cobra.Command{
 		utils.NoErr(err)
 
 		r := rollup.NewRollup(n, &rollup.Opts{
-			PollDelay:             time.Duration(cfg.Rollup.PollDelay) * time.Millisecond,
+			L1PollDelay:           time.Duration(cfg.Rollup.L1PollDelay) * time.Millisecond,
+			L2PollDelay:           time.Duration(cfg.Rollup.L2PollDelay) * time.Millisecond,
 			BundleSize:            cfg.Rollup.BundleSize,
 			StoreCelestiaPointers: cfg.Rollup.StoreCelestiaPointers,
 			StoreHeaders:          cfg.Rollup.StoreHeaders,

--- a/cli/cmd/rollup_start.go
+++ b/cli/cmd/rollup_start.go
@@ -30,7 +30,8 @@ var RollupStartCmd = &cobra.Command{
 		utils.NoErr(err)
 
 		r := rollup.NewRollup(n, &rollup.Opts{
-			PollDelay:             time.Duration(cfg.Rollup.PollDelay) * time.Millisecond,
+			L1PollDelay:           time.Duration(cfg.Rollup.L1PollDelay) * time.Millisecond,
+			L2PollDelay:           time.Duration(cfg.Rollup.L2PollDelay) * time.Millisecond,
 			BundleSize:            cfg.Rollup.BundleSize,
 			StoreCelestiaPointers: cfg.Rollup.StoreCelestiaPointers,
 			StoreHeaders:          cfg.Rollup.StoreHeaders,

--- a/config.json
+++ b/config.json
@@ -18,7 +18,8 @@
   },
   "rollup": {
     "bundleSize": 10,
-    "pollDelay": 10000,
+    "l1pollDelay": 30000,
+    "l2pollDelay": 10000,
     "storeCelestiaPointers": true,
     "storeHeaders": true
   }

--- a/config/config.go
+++ b/config/config.go
@@ -21,7 +21,8 @@ type Config struct {
 		Delay    int    `mapstructure:"delay"`
 	} `mapstructure:"lightlink"`
 	Rollup struct {
-		PollDelay             int    `mapstructure:"pollDelay"`
+		L1PollDelay           int    `mapstructure:"l1pollDelay"`
+		L2PollDelay           int    `mapstructure:"l2pollDelay"`
 		BundleSize            uint64 `mapstructure:"bundleSize"`
 		StoreCelestiaPointers bool   `mapstructure:"storeCelestiaPointers"`
 		StoreHeaders          bool   `mapstructure:"storeHeaders"`

--- a/rollup/rollup.go
+++ b/rollup/rollup.go
@@ -12,10 +12,11 @@ import (
 )
 
 type Opts struct {
-	BundleSize uint64        // BundleSize is the number of blocks to include in each bundle.
-	PollDelay  time.Duration // PollDelay is the time to wait between polling for new blocks.
-	Logger     *slog.Logger
-	DryRun     bool // DryRun indicates whether or not to actually submit the block to the L1 rollup contract.
+	BundleSize  uint64        // BundleSize is the number of blocks to include in each bundle.
+	L1PollDelay time.Duration // PollDelay is the time to wait between polling for new blocks on the L1 rollup contract.
+	L2PollDelay time.Duration // PollDelay is the time to wait between polling for new blocks on the L2 lightlink network.
+	Logger      *slog.Logger
+	DryRun      bool // DryRun indicates whether or not to actually submit the block to the L1 rollup contract.
 
 	StoreCelestiaPointers bool // StoreCelestiaPointers indicates whether or not to store the Celestia pointers in the local database.
 	StoreHeaders          bool // StoreHeaders indicates whether or not to store the rollup headers in the local database.
@@ -245,6 +246,8 @@ func (r *Rollup) Run() error {
 			"daTx", block.CelestiaPointer.TxHash.Hex(),
 			"l2_blocks", len(block.Blocks),
 		)
+
+		time.Sleep(r.Opts.L1PollDelay)
 	}
 
 }
@@ -275,6 +278,6 @@ func (r *Rollup) awaitL2Height(h uint64) error {
 			return nil
 		}
 
-		time.Sleep(r.Opts.PollDelay)
+		time.Sleep(r.Opts.L2PollDelay)
 	}
 }


### PR DESCRIPTION
Adds a delay to L1 polling to allow time for the previous tx to propagate through the network and the contract to be updated.