### PR TITLE
add config flag

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -4,7 +4,10 @@ import (
 	"hummingbird/cli/cmd"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
+
+var cfgFile string
 
 var rootCmd = &cobra.Command{
 	Use:   "hb",
@@ -19,6 +22,11 @@ var rollupCmd = &cobra.Command{
 var defenderCmd = &cobra.Command{
 	Use:   "defender",
 	Short: "defender is a command to generate proofs and respond to challenges",
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", ".", "config.json file path (default is .)")
+	viper.BindPFlag("config", rootCmd.PersistentFlags().Lookup("config"))
 }
 
 func main() {

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,8 @@
 package config
 
-import "github.com/spf13/viper"
+import (
+	"github.com/spf13/viper"
+)
 
 type Config struct {
 	StorePath string `mapstructure:"storePath"`
@@ -33,7 +35,7 @@ type Config struct {
 
 func Load() *Config {
 	viper.SetConfigName("config")
-	viper.AddConfigPath(".")
+	viper.AddConfigPath(viper.GetString("config"))
 	err := viper.ReadInConfig()
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Adds a config flag to the root command. Required for k8s as configMap is bound to a different volume. 