### PR TITLE
add config option to increase L1 tx gasPrice

### DIFF
--- a/config.json
+++ b/config.json
@@ -10,7 +10,8 @@
   "ethereum": {
     "endpoint": "https://ethereum-sepolia.publicnode.com",
     "canonicalStateChain": "0x18d00cfb6c7c78CAb803A225F4EE7F6307f22f4C",
-    "daOracle": "0x3a5cbB6EF4756DA0b3f6DAE7aB6430fD8c46d247"
+    "daOracle": "0x3a5cbB6EF4756DA0b3f6DAE7aB6430fD8c46d247",
+    "gasPriceIncreasePercent": 10
   },
   "lightlink": {
     "endpoint": "https://replicator.pegasus.lightlink.io/rpc/v1",

--- a/config/config.go
+++ b/config/config.go
@@ -14,9 +14,10 @@ type Config struct {
 		GRPC          string `mapstructure:"grpc"`
 	} `mapstructure:"celestia"`
 	Ethereum struct {
-		Endpoint            string `mapstructure:"endpoint"`
-		CanonicalStateChain string `mapstructure:"canonicalStateChain"`
-		DaOracle            string `mapstructure:"daOracle"`
+		Endpoint                string `mapstructure:"endpoint"`
+		CanonicalStateChain     string `mapstructure:"canonicalStateChain"`
+		DaOracle                string `mapstructure:"daOracle"`
+		GasPriceIncreasePercent int    `mapstructure:"gasPriceIncreasePercent"`
 	} `mapstructure:"ethereum"`
 	LightLink struct {
 		Endpoint string `mapstructure:"endpoint"`

--- a/node/ethereum.go
+++ b/node/ethereum.go
@@ -49,6 +49,7 @@ type EthereumClientOpts struct {
 	DAOracleAddress            common.Address
 	Logger                     *slog.Logger
 	DryRun                     bool
+	GasPriceIncreasePercent    *big.Int
 }
 
 // NewEthereumRPC returns a new EthereumRPC client.
@@ -109,6 +110,11 @@ func (e *EthereumClient) transactor() (*bind.TransactOpts, error) {
 		return nil, fmt.Errorf("failed to get gas price: %w", err)
 	}
 	opts.GasPrice = gasPrice
+
+	// If gas price increase percent is set, increase the gas price by the given percent.
+	if e.opts.GasPriceIncreasePercent != nil && e.opts.GasPriceIncreasePercent.Cmp(big.NewInt(0)) > 0 {
+		opts.GasPrice = gasPrice.Add(gasPrice, new(big.Int).Div(new(big.Int).Mul(gasPrice, e.opts.GasPriceIncreasePercent), big.NewInt(100)))
+	}
 
 	// If dry run is enabled, don't send the transaction.
 	if e.opts.DryRun {

--- a/node/node.go
+++ b/node/node.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"hummingbird/config"
 	"log/slog"
+	"math/big"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -27,6 +28,7 @@ func NewFromConfig(cfg *config.Config, logger *slog.Logger, ethKey *ecdsa.Privat
 		Signer:                     ethKey,
 		Logger:                     logger.With("ctx", "ethereum"),
 		DryRun:                     cfg.DryRun,
+		GasPriceIncreasePercent:    big.NewInt(int64(cfg.Ethereum.GasPriceIncreasePercent)),
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When submitting blocks to Sepolia with the suggested `gasPrice`, it frequently takes 30+ minutes for the tx to be included and the CSC contract to update. This results in the same block being posted multiple times and multiple failed txns. Increasing the `gasPrice` seems to prevent this by speeding up tx inclusion.

Added a `gasPriceIncreasePercent` config var.