### PR TITLE
add fee and gasPrice logic

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,7 +5,8 @@
     "endpoint": "http://164.92.75.29:26658",
     "namespace": "lightlink",
     "tendermint_rpc": "http://full.consensus.mocha-4.celestia-mocha.com:26657",
-    "grpc": "full.consensus.mocha-4.celestia-mocha.com:9090"
+    "grpc": "full.consensus.mocha-4.celestia-mocha.com:9090",
+    "gasPrice": 0.003
   },
   "ethereum": {
     "endpoint": "https://ethereum-sepolia.publicnode.com",

--- a/config/config.go
+++ b/config/config.go
@@ -7,11 +7,12 @@ import (
 type Config struct {
 	StorePath string `mapstructure:"storePath"`
 	Celestia  struct {
-		Token         string `mapstructure:"token"`
-		Endpoint      string `mapstructure:"endpoint"`
-		Namespace     string `mapstructure:"namespace"`
-		TendermintRPC string `mapstructure:"tendermint_rpc"`
-		GRPC          string `mapstructure:"grpc"`
+		Token         string  `mapstructure:"token"`
+		Endpoint      string  `mapstructure:"endpoint"`
+		Namespace     string  `mapstructure:"namespace"`
+		TendermintRPC string  `mapstructure:"tendermint_rpc"`
+		GRPC          string  `mapstructure:"grpc"`
+		GasPrice      float64 `mapstructure:"gasPrice"`
 	} `mapstructure:"celestia"`
 	Ethereum struct {
 		Endpoint                string `mapstructure:"endpoint"`

--- a/node/node.go
+++ b/node/node.go
@@ -41,6 +41,7 @@ func NewFromConfig(cfg *config.Config, logger *slog.Logger, ethKey *ecdsa.Privat
 		TendermintRPC: cfg.Celestia.TendermintRPC,
 		Namespace:     cfg.Celestia.Namespace,
 		Logger:        logger.With("ctx", "celestia"),
+		GasPrice:      cfg.Celestia.GasPrice,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Celestia devs confirmed this logic to calculate the optimal fee. There are not many complete examples on their docs and all of GitHub.

Unlike Ethereum, there is no `gasPrice` API. Instead, `gasPrice` is set by node operators. From Celestia docs:

> As of version v1.0.0 of the application (celestia-app), there is no protocol enforced minimum fee (similar to EIP-1559 in Ethereum). Instead, each consensus node running a mempool uses a locally configured gas price threshold that must be met in order for that node to accept a transaction, either directly from a user or gossiped from another node, into its mempool.
> 
> As of version v1.0.0 of the application (celestia-app), gas is not refunded. Instead, transaction fees are deducted by a flat fee, originally specified by the user in their tx (where fees = gasLimit * gasPrice). This means that users should use an accurate gas limit value if they do not wish to over pay.
