### PR TITLE
multiple improvements

### DIFF
--- a/cli/hb/cmd/defender_provide.go
+++ b/cli/hb/cmd/defender_provide.go
@@ -70,6 +70,11 @@ var DefenderProvideCmd = &cobra.Command{
 			return
 		}
 
+		if tx == nil {
+			logger.Error("Transaction is nil")
+			return
+		}
+
 		fmt.Println(" ")
 		fmt.Println("Tx Hash:", tx.Hash().Hex())
 		fmt.Println("Provided L2 Data:", targetHash.Hex())

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -17,6 +17,7 @@ ethereum:
   blobstreamX: "0xc3e209eb245Fd59c8586777b499d6A665DF3ABD2"
   gasPriceIncreasePercent: 10 # Gas price increase percent e.g 10% increase from current gas price
   blockTime: 200 # block time in ms, used to calculate number of blocks to scan logs
+  timeout: 15 # Timeout in mins for each request
 lightlink:
   endpoint: https://replicator.pegasus.lightlink.io/rpc/v1 # Lightlink endpoint
   delay: 500 # Delay in ms between each request

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -5,7 +5,10 @@ celestia:
   namespace: lightlink # Celestia blob namespace
   tendermint_rpc: http://full.consensus.mocha-4.celestia-mocha.com:26657 # Tendermint RPC endpoint
   gasPrice: 0.003 # Gas price in TIA
-  retries: 0 # Number of retries when a submitBlob request fails
+  gasPriceIncreasePercent: 0 # Gas price increase percent e.g 10% increase from current gas price
+  gasAPI: # Gas API endpoint to get current gas price
+  retries: 3 # Number of retries for each request
+  retryDelay: 120000 # Delay in ms between each retry
 ethereum:
   httpEndpoint: https://ethereum-sepolia.publicnode.com # Ethereum HTTP endpoint
   canonicalStateChain: "0x18d00cfb6c7c78CAb803A225F4EE7F6307f22f4C" # Canonical state chain contract address

--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,7 @@ type Config struct {
 		ChainOracle             string `mapstructure:"chainOracle"`
 		BlobstreamX             string `mapstructure:"blobstreamX"`
 		BlockTime               int    `mapstructure:"blockTime"`
+		Timeout                 int    `mapstructure:"timeout"`
 	} `mapstructure:"ethereum"`
 	LightLink struct {
 		Endpoint string `mapstructure:"endpoint"`

--- a/node/ethereum/challenge.go
+++ b/node/ethereum/challenge.go
@@ -25,6 +25,8 @@ type Challenge interface {
 	GetChallengeWindow() (*big.Int, error)
 	GetChallengeWindowBlockRanges() ([][]uint64, error)
 	DataRootInclusionChallengeKey(opts *bind.CallOpts, blockHash common.Hash, pointerIndex uint8, shareIndex uint32) (common.Hash, error)
+	ClaimDAChallengeReward(key common.Hash) (*common.Hash, error)
+	ClaimL2HeaderChallengeReward(key common.Hash) (*common.Hash, error)
 }
 
 var _ Challenge = &Client{} // Ensure Client implements Challenge
@@ -191,4 +193,36 @@ func (c *Client) GetChallengeWindowBlockRanges() ([][]uint64, error) {
 	blockRanges = append(blockRanges, []uint64{startBlock, currentBlock})
 
 	return blockRanges, nil
+}
+
+func (c *Client) ClaimDAChallengeReward(key common.Hash) (*common.Hash, error) {
+	transactor, err := c.transactor()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create transactor: %w", err)
+	}
+
+	tx, err := c.challenge.ClaimDAChallengeReward(transactor, key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to claim DA challenge reward: %w", err)
+	}
+
+	hash := tx.Hash()
+
+	return &hash, nil
+}
+
+func (c *Client) ClaimL2HeaderChallengeReward(key common.Hash) (*common.Hash, error) {
+	transactor, err := c.transactor()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create transactor: %w", err)
+	}
+
+	tx, err := c.challenge.ClaimL2HeaderChallengeReward(transactor, key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to claim L2 header challenge reward: %w", err)
+	}
+
+	hash := tx.Hash()
+
+	return &hash, nil
 }

--- a/node/ethereum/ethereum.go
+++ b/node/ethereum/ethereum.go
@@ -7,6 +7,7 @@ import (
 	"hummingbird/utils"
 	"log/slog"
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -55,6 +56,7 @@ type ClientOpts struct {
 	DryRun                     bool
 	GasPriceIncreasePercent    *big.Int
 	BlockTime                  int
+	Timeout                    time.Duration
 }
 
 // NewEthereumRPC returns a new EthereumRPC client over HTTP.

--- a/node/node.go
+++ b/node/node.go
@@ -85,6 +85,9 @@ func NewFromConfig(cfg *config.Config, logger *slog.Logger, ethKey *ecdsa.Privat
 	}
 
 	logger.Info("Rollup Node created!", "dryRun", cfg.DryRun)
+
+	logger.Info("Ethereum private key address", "address", crypto.PubkeyToAddress(ethKey.PublicKey).Hex())
+
 	return &Node{
 		Ethereum:  eth,
 		Celestia:  cel,

--- a/node/node.go
+++ b/node/node.go
@@ -45,6 +45,7 @@ func NewFromConfig(cfg *config.Config, logger *slog.Logger, ethKey *ecdsa.Privat
 		DryRun:                     cfg.DryRun,
 		GasPriceIncreasePercent:    big.NewInt(int64(cfg.Ethereum.GasPriceIncreasePercent)),
 		BlockTime:                  cfg.Ethereum.BlockTime,
+		Timeout:                    time.Duration(cfg.Ethereum.Timeout) * time.Minute,
 	})
 	if err != nil {
 		return nil, err

--- a/rollup/rollup.go
+++ b/rollup/rollup.go
@@ -274,7 +274,11 @@ func (r *Rollup) Run() error {
 			"l2_blocks", len(block.L2Blocks()),
 		)
 
-		time.Sleep(r.Opts.L1PollDelay)
+		_, err = r.Ethereum.Wait(tx.Hash())
+		if err != nil {
+			log.Error("failed to wait for tx", "error", err)
+			return err
+		}
 	}
 
 }


### PR DESCRIPTION
- adds missing new config vars to the example config .env file
- logs the address of the private key `ETH_KEY` env var on startup
- fixes `Ethereum.Wait()` function by waiting for tx receipts
- automatically claims DA & L2 Header challenge rewards after defending (useful as we can run constant challenge bot to test and don't have to claim eth back for hundreds of challenges manually)

![CleanShot 2024-06-06 at 22 19 38@2x](https://github.com/lightlink-network/hummingbird-client/assets/13082186/8b26c0a2-fe18-423d-9eab-814eb88c4ce1)

![CleanShot 2024-06-06 at 22 20 02@2x](https://github.com/lightlink-network/hummingbird-client/assets/13082186/39b6a2ca-bbf9-45b7-b0ab-37f7bd8a6805)
