### PR TITLE
upload bundles directly after fetching

### DIFF
--- a/rollup/rollup.go
+++ b/rollup/rollup.go
@@ -95,7 +95,7 @@ func (r *Rollup) CreateNextBlock() (*Block, error) {
 	fetchTarget := head.L2Height + blocksToFetch
 	fetchStart := head.L2Height + 1
 
-	bundles, err := r.fetchBundles(fetchStart, fetchTarget)
+	bundles, pointers, err := r.fetchBundles(fetchStart, fetchTarget)
 	if err != nil {
 		return nil, fmt.Errorf("createNextBlock: Failed to fetch bundles: %w", err)
 	}
@@ -106,27 +106,16 @@ func (r *Rollup) CreateNextBlock() (*Block, error) {
 		return nil, fmt.Errorf("createNextBlock: Failed to validate bundles: %w", err)
 	}
 
-	// 7. upload the bundle to celestia
-	r.Opts.Logger.Info("Publishing bundles to Celestia", "bundles", len(bundles), "bundles_size", fetchStart-head.L2Height-1, "ll_height", llHeight, "ll_epoch", epoch)
-	pointers := make([]canonicalStateChainContract.CanonicalStateChainCelestiaPointer, 0)
-	for i, bundle := range bundles {
-		pointer, gasPrice, err := r.Celestia.PublishBundle(*bundle)
-		if err != nil {
-			return nil, fmt.Errorf("createNextBlock: Failed to publish bundle: %w", err)
-		}
-		r.Opts.Logger.Debug("Published bundle to Celestia", "gas_price", gasPrice, "bundle", i, "bundle_size", bundle.Size(), "celestia_tx", pointer.TxHash.Hex())
-		pointers = append(pointers, canonicalStateChainContract.CanonicalStateChainCelestiaPointer{
-			Height:     pointer.Height,
-			ShareStart: big.NewInt(int64(pointer.ShareStart)),
-			ShareLen:   uint16(pointer.ShareLen),
-		})
-
-		// Delay between publishing bundles to Celestia to mitigate 'incorrect account sequence' errors
-		time.Sleep(20 * time.Second)
-	}
-
 	if len(bundles) == 0 {
 		return nil, fmt.Errorf("createNextBlock: No bundles to publish")
+	}
+
+	if len(pointers) == 0 {
+		return nil, fmt.Errorf("createNextBlock: No pointers to publish")
+	}
+
+	if len(bundles) != len(pointers) {
+		return nil, fmt.Errorf("createNextBlock: Bundles and pointers are not the same length")
 	}
 
 	// 8. create the rollup header
@@ -339,8 +328,9 @@ func (r *Rollup) GetBlockByHash(hash common.Hash) (*Block, error) {
 	return &Block{CanonicalStateChainHeader: &header, Bundles: bundles}, nil
 }
 
-func (r *Rollup) fetchBundles(fetchStart, fetchTarget uint64) ([]*node.Bundle, error) {
+func (r *Rollup) fetchBundles(fetchStart, fetchTarget uint64) ([]*node.Bundle, []canonicalStateChainContract.CanonicalStateChainCelestiaPointer, error) {
 	bundles := make([]*node.Bundle, 0)
+	pointers := make([]canonicalStateChainContract.CanonicalStateChainCelestiaPointer, 0)
 
 	for fetchStart < fetchTarget && uint64(len(bundles)) < r.Opts.BundleCount {
 		from := fetchStart
@@ -352,17 +342,37 @@ func (r *Rollup) fetchBundles(fetchStart, fetchTarget uint64) ([]*node.Bundle, e
 		bundle, err := r.fetchBundle(from, to)
 		if err != nil {
 			r.Opts.Logger.Error("Failed to fetch bundle", "from", from, "to", to, "error", err)
+			return nil, nil, err
 		} else {
 			bundles = append(bundles, bundle)
 		}
 
+		// upload the bundle to celestia
+		r.Opts.Logger.Info("Publishing bundle to Celestia", "bundle", len(bundles), "bundle_size", bundle.Size(), "ll_height", bundle.Blocks[len(bundle.Blocks)-1].Number())
+
+		pointer, gasPrice, err := r.Celestia.PublishBundle(*bundle)
+		if err != nil {
+			return nil, nil, fmt.Errorf("createNextBlock: Failed to publish bundle: %w", err)
+		}
+
+		r.Opts.Logger.Debug("Published bundle to Celestia", "gas_price", gasPrice, "bundle", len(bundles), "bundle_size", bundle.Size(), "celestia_tx", pointer.TxHash.Hex())
+
+		pointers = append(pointers, canonicalStateChainContract.CanonicalStateChainCelestiaPointer{
+			Height:     pointer.Height,
+			ShareStart: big.NewInt(int64(pointer.ShareStart)),
+			ShareLen:   uint16(pointer.ShareLen),
+		})
+
 		fetchStart = bundle.Blocks[len(bundle.Blocks)-1].Number().Uint64() + 1
 	}
 
-	return bundles, nil
+	return bundles, pointers, nil
 }
 
 func (r *Rollup) fetchBundle(from, to uint64) (*node.Bundle, error) {
+
+	r.Opts.Logger.Info("Fetching bundle", "from", from, "to", to)
+
 	if r.Opts.Store {
 		bundle, err := r.Node.Store.GetBundle(from, to)
 		if err == nil {
@@ -387,6 +397,8 @@ func (r *Rollup) fetchBundle(from, to uint64) (*node.Bundle, error) {
 			r.Opts.Logger.Info("Stored bundle in local database", "from", from, "to", to, "bundle_size", len(l2blocks))
 		}
 	}
+
+	r.Opts.Logger.Info("Fetched bundle", "from", from, "expected_to", to, "actual_to", l2blocks[len(l2blocks)-1].Number(), "bundle_size", len(l2blocks))
 
 	return bundle, nil
 }


### PR DESCRIPTION
- Upload bundles to Celestia directly after the bundle is fetched from RPC or db.
- This is an attempt to reduce Celestia fees by reducing the network congestion caused by hb
- If a bundle fetch fails, the entire batch/header will be refetched
- If a bundle upload fails, the entire batch/header will be refetched